### PR TITLE
Allow for graphql without mutations.

### DIFF
--- a/src/generate/schema.js
+++ b/src/generate/schema.js
@@ -10,6 +10,16 @@ const generateSchema = ({
   globalPreCallback = () => null,
   pubSubInstance
 }) => {
+  const mutationExists =
+    !!customMutations ||
+    Object.values(graphqlSchemaDeclaration).some(type => {
+      if (type.actions) {
+        return ['create', 'delete', 'update'].some(action =>
+          type.actions.includes(action)
+        )
+      }
+    })
+
   const definition = {
     query: generateQueryRootResolver(
       graphqlSchemaDeclaration,
@@ -17,15 +27,17 @@ const generateSchema = ({
       models,
       globalPreCallback
     ),
-    mutation: generateMutation(
-      graphqlSchemaDeclaration,
-      types.inputTypes,
-      types.outputTypes,
-      models,
-      globalPreCallback,
-      customMutations,
-      pubSubInstance
-    )
+    ...(mutationExists && {
+      mutation: generateMutation(
+        graphqlSchemaDeclaration,
+        types.inputTypes,
+        types.outputTypes,
+        models,
+        globalPreCallback,
+        customMutations,
+        pubSubInstance
+      )
+    })
   }
 
   // Do not generate subscriptions if no ways of propagating information is defined.

--- a/src/generate/schema.js
+++ b/src/generate/schema.js
@@ -18,6 +18,7 @@ const generateSchema = ({
           type.actions.includes(action)
         )
       }
+      return !!type.additionalMutations
     })
 
   const definition = {


### PR DESCRIPTION
# Overview

According to the [Graphql Specs](http://spec.graphql.org/June2018/#sec-Root-Operation-Types), a Graphql schema must have queries but mutations are optional. 

Currently, if no mutations are offered, an error is thrown. To fix this in my app, after the schema was generated, I simply did:

```node
delete graphqlSchema._typeMap.Root_Mutations;
graphqlSchema._mutationType = undefined;
```

But that seems fairly hacky. This PR fixes this issue by allowing the creation of a schema with no mutations.

