### PR TITLE
Add hook to prevent duplicate on attributes

### DIFF
--- a/lib/mutationResolvers/create.js
+++ b/lib/mutationResolvers/create.js
@@ -81,7 +81,7 @@ function generateMutationCreate(modelName, inputType, outputType, model, graphql
             ? graphqlModelDeclaration.create.extraArg
             : {})),
         resolve: function (source, args, context, info) { return __awaiter(_this, void 0, void 0, function () {
-            var attributes, beforeList, beforeList_1, beforeList_1_1, before, handle, e_1_1, beforeHandle, newEntity, afterHandle, updatedEntity;
+            var attributes, beforeList, beforeList_1, beforeList_1_1, before, handle, e_1_1, beforeHandle, preventDuplicateAttributes_1, filters, entityDuplicate, newEntity, afterHandle, updatedEntity;
             var e_1, _a, _b, _c;
             return __generator(this, function (_d) {
                 switch (_d.label) {
@@ -128,18 +128,42 @@ function generateMutationCreate(modelName, inputType, outputType, model, graphql
                         return [4 /*yield*/, graphqlModelDeclaration.create.before(source, args, context, info)];
                     case 9:
                         attributes = _d.sent();
+                        if (!attributes) {
+                            throw new Error('The before hook must always return the create method first parameter.');
+                        }
                         if (beforeHandle) {
                             beforeHandle();
                         }
                         _d.label = 10;
-                    case 10: return [4 /*yield*/, model.create(attributes)];
+                    case 10:
+                        if (!(graphqlModelDeclaration.create &&
+                            graphqlModelDeclaration.create.preventDuplicateOnAttributes)) return [3 /*break*/, 13];
+                        return [4 /*yield*/, graphqlModelDeclaration.create.preventDuplicateOnAttributes()];
                     case 11:
+                        preventDuplicateAttributes_1 = _d.sent();
+                        filters = Object.keys(attributes).reduce(function (acc, key) {
+                            if (preventDuplicateAttributes_1.includes(key)) {
+                                acc[key] = attributes[key];
+                            }
+                            return acc;
+                        }, {});
+                        return [4 /*yield*/, model.findOne({
+                                where: filters
+                            })];
+                    case 12:
+                        entityDuplicate = _d.sent();
+                        if (entityDuplicate) {
+                            return [2 /*return*/, entityDuplicate];
+                        }
+                        _d.label = 13;
+                    case 13: return [4 /*yield*/, model.create(attributes)];
+                    case 14:
                         newEntity = _d.sent();
                         if (!(graphqlModelDeclaration.create &&
-                            graphqlModelDeclaration.create.after)) return [3 /*break*/, 13];
+                            graphqlModelDeclaration.create.after)) return [3 /*break*/, 16];
                         afterHandle = globalPreCallback('createAfter');
                         return [4 /*yield*/, graphqlModelDeclaration.create.after(newEntity, source, args, context, info)];
-                    case 12:
+                    case 15:
                         updatedEntity = _d.sent();
                         if (afterHandle) {
                             afterHandle();
@@ -150,7 +174,7 @@ function generateMutationCreate(modelName, inputType, outputType, model, graphql
                                 _b));
                         }
                         return [2 /*return*/, updatedEntity];
-                    case 13:
+                    case 16:
                         if (pubSubInstance) {
                             pubSubInstance.publish(modelName + "Created", (_c = {},
                                 _c[modelName + "Created"] = newEntity.get(),

--- a/src/tests/__snapshots__/mutation.create.spec.js.snap
+++ b/src/tests/__snapshots__/mutation.create.spec.js.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Test the create mutation Check if you cannot duplicate entity according to attributes 1`] = `
+Object {
+  "userCreate": Object {
+    "id": 25001,
+    "name": "new user",
+  },
+}
+`;
+
 exports[`Test the create mutation Check that you can create a new instance of one entity 1`] = `
 Array [
   "listGlobalBefore",

--- a/src/tests/schema.js
+++ b/src/tests/schema.js
@@ -104,6 +104,9 @@ graphqlSchemaDeclaration.user = {
     after: async (newEntity, source, args, context, info) => {
       // You can log what happened here
       return newEntity
+    },
+    preventDuplicateOnAttributes: () => {
+      return ['name']
     }
   },
   update: {


### PR DESCRIPTION
The purpose of this pr is to add a hook (preventDuplicateOnAttributes) to the create resolver. This hook allows to avoid duplication of entities following specific attributes.



